### PR TITLE
fix: remove comment from JSON file to prevent web app crashes

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -166,14 +166,13 @@ in
         root = pkgs.fedimint-ui;
       };
       locations."=/config.json" = {
-        alias = pkgs.writeText "config.json"
-          ''
-            {
-                "fm_config_api": "wss://${fmApiFqdn}/ws/",
-                # CHANGEME: ToS that will be displayed to the Admin
-                "tos": "ToS "
-            }
-          '';
+        # CHANGEME: specify Terms Of Service (ToS) for the federation in the field tos
+        alias = pkgs.writeText "config.json" ''
+          {
+              "fm_config_api": "wss://${fmApiFqdn}/ws/",
+              "tos": "Term of Services for this federation"
+          }
+        '';
       };
     };
   };


### PR DESCRIPTION
The `# CHANGEME` comment in the `config.json` writer is incorrectly included in the output, which is not ignored by Nix. As a result, the web application crashes when trying to load the page.

Although this comment is meant for reference, some users may overlook removing it, leading to the deployment of a broken web application.