### PR TITLE
chore: update Fedimint version to v0.4.3

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -108,16 +108,10 @@ in
     extraEnvironment = {
       "RUST_LOG" = "info";
       "RUST_BACKTRACE" = "1";
+      "FM_REL_NOTES_ACK" = "0_4_xyz";
     };
-    api = {
-      address = "wss://${fmApiFqdn}/ws/";
-      bind = "127.0.0.1";
-    };
-    p2p = {
-      address = "fedimint://${fmP2pFqdn}:8173";
-      openFirewall = true;
-      bind = "0.0.0.0";
-    };
+    api.fqdn = fmApiFqdn;
+    p2p.fqdn = fmP2pFqdn;
     bitcoin = {
       network = "bitcoin";
       rpc = {

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,7 @@
     };
     fedimint = {
       # CHANGEME: change to a version you'd like to use
-      # url = "github:fedimint/fedimint?ref=refs/tags/v0.3.1";
-      url = "github:fedimint/fedimint?rev=d2840ae5d9988eed601f9bc917d4f2028c7bcee9";
+      url = "github:fedimint/fedimint?ref=refs/tags/v0.4.3";
     };
     fedimint-ui = {
       url = "github:fedimint/ui?rev=b57151db3bc4afa373cd61d67b8677e0ba38ceeb";


### PR DESCRIPTION
The upgrade from `v0.3` to `v0.4` involves significant effort. Therefore, it's preferable to have the template point to the stable `v0.4.3` release.